### PR TITLE
Update README.md - Broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To get started with the first exercise, simply run the following commands in you
 git clone https://github.com/SAP-samples/sapui5-development-learning-journey
 ```
 
-We recommend to follow the instructions in the [learning journey](https://learning.sap.com/learning-journey/sapui5-development-learning-journey) to get started.
+We recommend to follow the instructions in the [learning journey](https://learning.sap.com/learning-journeys/develop-sapui5-applications) to get started.
 
 
 If you want to start or continue from a specific unit or exercise, get the name of its branch from the tutorial, clone this repository and switch to the desired branch:


### PR DESCRIPTION
The link "learning journey" in this [page](https://github.com/SAP-samples/sapui5-development-learning-journey):
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; <img src="https://github.com/user-attachments/assets/a16c536c-64bb-478c-9adb-1f195fb22eb4">

goes to a 404 page:
https://learning.sap.com/learning-journeys/sapui5-development-learning-journey

I guess it should go to this page:
https://learning.sap.com/learning-journeys/develop-sapui5-applications