### PR TITLE
Update mockserver middleware dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@ui5/cli": "^2.14.1",
     "@sap/ux-ui5-tooling": "1",
-    "@sap/ux-ui5-fe-mockserver-middleware": "1"
+    "@sap-ux/ui5-middleware-fe-mockserver": "2"
   },
   "scripts": {
     "start": "fiori run --open \"test/flpSandbox.html?sap-client=100&sap-ui-xx-viewCache=false#saptrainingexc-display\"",
@@ -30,7 +30,7 @@
   "ui5": {
     "dependencies": [
       "@sap/ux-ui5-tooling",
-      "@sap/ux-ui5-fe-mockserver-middleware"
+      "@sap-ux/ui5-middleware-fe-mockservre"
     ]
   },
   "sapuxLayer": "CUSTOMER_BASE"


### PR DESCRIPTION
As `@sap/ux-ui5-fe-mockserver-middleware` is deprecated since a quadruple of year I updated to the correct dependency `@sap-ux/ui5-middleware-fe-mockserver`